### PR TITLE
All fields are marked as invalid due to incorrect model expression handling

### DIFF
--- a/BSolutions.Brecons/BSolutions.Brecons.Core/Extensions/FormTagHelperExtensions.cs
+++ b/BSolutions.Brecons/BSolutions.Brecons.Core/Extensions/FormTagHelperExtensions.cs
@@ -55,7 +55,7 @@ namespace BSolutions.Brecons.Core.Extensions
         {
             if (tagHelper.For != null && tagHelper.ViewContext.HttpContext.Request.Method == "POST")
             {
-                return tagHelper.ViewContext.ViewData.ModelState.GetFieldValidationState(tagHelper.For.Metadata.PropertyName) == ModelValidationState.Valid;
+                return tagHelper.ViewContext.ViewData.ModelState.GetFieldValidationState(tagHelper.For.Name) != ModelValidationState.Invalid;
             }
 
             return true;


### PR DESCRIPTION
Fixes a bug in validation after a POST to the same view when the Model has nestes properties. For example:
for Location.Name., the code got only Name.

Also, checking agains ModelValidationState.Invalid seems safer than checking explicitely for ModelValidationState.Valid, as the possible values are:

public enum ModelValidationState
    {
        Unvalidated = 0,
        Invalid = 1,
        Valid = 2,
        Skipped = 3
    }